### PR TITLE
Remove Ship.io from list

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ Online build release system
 * [wercker](http://wercker.com)  Test and deploy your applications with ease  
 * [codecov](https://codecov.io)  Continuous code coverage. Featuring browser extenstions and awesome pull request commentsto track coverage over time on your GitHub/Bitbucket/Gitlab repo  
 * [coveralls](https://coveralls.io)  Track your project's code coverage over time, changes to files, and badge your GitHub repo  
-* [ship.io](https://ship.io/)  Simple, powerful CI for iOS and Android. Re-build, Re-test, Re-deploy.  
 * [GitLab CI](https://www.gitlab.com/gitlab-ci/) - Based off of ruby. They also provide GitLab, which manages git repositories. 
 * [IBM DevOps Services](https://hub.jazz.net) - Develop, track, plan, and deploy software onto the IBM Bluemix cloud platform.  
 


### PR DESCRIPTION
Ship.io will be terminated at October 30, 2015. Check message on their main page.