### PR TITLE
Remove solano CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ The theory for continuous integration and continuous deliver
 
 ## Build And Release System
 The system for software build and release, continuous integration and continuous delivery  
-* [Jenkins](http://jenkins-ci.org)  An extendable open source continuous integration server  
-* [Solano CI](https://www.solanolabs.com)  Faster Continuous Integration and Deployment with patented auto-parallelization. See results 10 to 80x faster. 14-day free trial. No credit card required.
+* [Jenkins](http://jenkins-ci.org)  An extendable open source continuous integration server
 * [Concourse](https://concourse-ci.org) Rather than a myriad of checkboxes, pipelines are defined as a single declarative config file
 * [BuildForge](https://jazz.net/downloads/rational-build-forge/)  Automate and accelerate build and release processes  
 * [ElectricFlow](http://electric-cloud.com/products/electricflow/)  ElectricFlow/ElectricCommander gives distributed teams shared control and visibility into infrastructure, tool chains and processes. It accelerates and automates the software delivery process to enable agility, predictability and security across many build-test-deploy pipelines  


### PR DESCRIPTION
The company does not exist anymore, and the service is discontinued. If you open the URL, you will see a placeholder website for the domain.