### PR TITLE
Add Veritensor to the secure tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Provision tools
 Secure tools
 * [Deepfence Enterprise](https://deepfence.io) - Full life cycle Cloud Native Workload Protection platform for kubernetes, virtual machines and serverless.
 * [Deepfence Threat Mapper](https://github.com/deepfence/ThreatMapper) - Powerful runtime vulnerability scanner for kubernetes, virtual machines and serverless.
+* [Veritensor](https://github.com/ArseniiBrazhnyk/Veritensor) - DevSecOps security testing tool for AI/ML artifacts. Performs static analysis of model files and software composition checks (licenses, hashes) to prevent deploying malicious or non-compliant models.
 * [whitesource](https://www.whitesourcesoftware.com/) The simplest way to secure and manage open source components in your software.  
 
 ## Web Server

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Provision tools
 Secure tools
 * [Deepfence Enterprise](https://deepfence.io) - Full life cycle Cloud Native Workload Protection platform for kubernetes, virtual machines and serverless.
 * [Deepfence Threat Mapper](https://github.com/deepfence/ThreatMapper) - Powerful runtime vulnerability scanner for kubernetes, virtual machines and serverless.
-* [Veritensor](https://github.com/ArseniiBrazhnyk/Veritensor) - DevSecOps security testing tool for AI/ML artifacts. Performs static analysis of model files and software composition checks (licenses, hashes) to prevent deploying malicious or non-compliant models.
+* [Veritensor](https://github.com/arsbr/Veritensor) - CI/CD security gate for AI projects. Automatically blocks malicious ML models, poisoned datasets, and leaked secrets before deployment.
 * [whitesource](https://www.whitesourcesoftware.com/) The simplest way to secure and manage open source components in your software.  
 
 ## Web Server


### PR DESCRIPTION
Hi! I'd like to propose adding Veritensor to the tools section.

Veritensor brings traditional DevSecOps practices (SAST/SCA) to the AI Supply Chain. It is a CLI tool designed to run in CI/CD pipelines to secure AI artifacts before deployment.

**Features**:
- **Models:** Deep AST analysis of Pickle/PyTorch files to detect RCE and backdoors without executing them.
- **Data & RAG:** Scans datasets (Parquet) and documents (PDF) for Data Poisoning and Prompt Injections.
- **Notebooks:** Detects leaked secrets and malicious magics in Jupyter Notebooks.
- **SCA:** Verifies cryptographic hashes against upstream registries (Hugging Face) and audits dependencies for Typosquatting.
**Repo:** [https://github.com/arsbr/Veritensor](https://www.google.com/url?sa=E&q=https%3A%2F%2Fgithub.com%2FArseniiBrazhnyk%2FVeritensor)
**License:** Apache 2.0
**Integration:** Native GitHub Action available.

Proposed entry for the README.md:
- [Veritensor](https://github.com/arsbr/Veritensor) - CI/CD security gate for AI projects. Automatically blocks malicious ML models, poisoned datasets, and leaked secrets before deployment.

Thanks!