### PR TITLE
Add bytebase to Database Version Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Database version control system
 * [Rumba RDBM](https://www.dbinvent.com/) Database migration tool, plain-SQL, and declarative definition supported.
 * [dbdeploy](http://dbdeploy.com) dbdeploy is a Database Change Management tool. It’s for developers or DBAs who want to evolve their database design – or refactor their database – in a simple, controlled, flexible and frequent manner   
 * [dbmaestro](http://www.dbmaestro.com/)  Controlled Database Continuous Delivery is Our Business  
-* [bytebase](https://www.bytebase.com) database governance platform with a UI-driven or GitOps workflow, versioned or declarative migrations, SQL review, and a full API  
+* [bytebase](https://www.bytebase.com) database governance platform supporting both UI-driven and GitOps database CI/CD workflows — version-controlled schema migrations, SQL review, and pipeline integration across MySQL, PostgreSQL, and 20+ engines  
 
 ## Useful Sites
 Other useful pages  

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Database version control system
 * [Rumba RDBM](https://www.dbinvent.com/) Database migration tool, plain-SQL, and declarative definition supported.
 * [dbdeploy](http://dbdeploy.com) dbdeploy is a Database Change Management tool. It’s for developers or DBAs who want to evolve their database design – or refactor their database – in a simple, controlled, flexible and frequent manner   
 * [dbmaestro](http://www.dbmaestro.com/)  Controlled Database Continuous Delivery is Our Business  
-* [bytebase](https://www.bytebase.com) database CI/CD with schema migration, SQL review, and change approval workflows  
+* [bytebase](https://www.bytebase.com) database CI/CD with a GitOps workflow, versioned or declarative migrations, SQL review, and a full API  
 
 ## Useful Sites
 Other useful pages  

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Database version control system
 * [Rumba RDBM](https://www.dbinvent.com/) Database migration tool, plain-SQL, and declarative definition supported.
 * [dbdeploy](http://dbdeploy.com) dbdeploy is a Database Change Management tool. It’s for developers or DBAs who want to evolve their database design – or refactor their database – in a simple, controlled, flexible and frequent manner   
 * [dbmaestro](http://www.dbmaestro.com/)  Controlled Database Continuous Delivery is Our Business  
+* [bytebase](https://www.bytebase.com) database CI/CD with schema migration, SQL review, and change approval workflows  
 
 ## Useful Sites
 Other useful pages  

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Database version control system
 * [Rumba RDBM](https://www.dbinvent.com/) Database migration tool, plain-SQL, and declarative definition supported.
 * [dbdeploy](http://dbdeploy.com) dbdeploy is a Database Change Management tool. It’s for developers or DBAs who want to evolve their database design – or refactor their database – in a simple, controlled, flexible and frequent manner   
 * [dbmaestro](http://www.dbmaestro.com/)  Controlled Database Continuous Delivery is Our Business  
-* [bytebase](https://www.bytebase.com) database CI/CD with a GitOps workflow, versioned or declarative migrations, SQL review, and a full API  
+* [bytebase](https://www.bytebase.com) database governance platform with a UI-driven or GitOps workflow, versioned or declarative migrations, SQL review, and a full API  
 
 ## Useful Sites
 Other useful pages  


### PR DESCRIPTION
Adds [Bytebase](https://github.com/bytebase/bytebase) to the **Database Version Control** section, alongside liquibase, flywaydb and dbmaestro.

Bytebase is a database governance platform — change management, access control, and audit/compliance as one system — with **two workflows**:

- **UI-driven** — create and review the change in the Bytebase console, no repo required.
- **GitOps** — migration files live in the repo, land through a PR/MR, and Bytebase applies them and tracks revisions. Supports both **versioned** (SQL files, the model liquibase/flywaydb use) and **declarative** (SDL — target schema defined, DDL diffed and generated) migrations.

Both share the same review/approval/rollout lifecycle. For a CI/CD context specifically: SQL review rules that run as a PR check, an approval gate before production, and a **full API** — 33 gRPC services with REST mappings (projects, databases, plans, rollouts, releases, revisions, users, roles, policies) — so pipelines can drive the whole thing rather than shelling out to a CLI.

~14.4k stars, actively maintained. Formatting follows the existing entries in that section.

Disclosure: I work on Bytebase.